### PR TITLE
Improve restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 py3rcon
 ============
+<sup>Version: 0.2.1 | Authors: indepth666 (Basic protocol design), ole1986 (CLI)</sup>
 
 py3rcon is a Python3 client for Battleye Rcon protocol. 
 It's designed with ARMA2 and ARMA3 in mind but may also work with other implemenation of the protocol.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ server : rcon_password  | yourPW         | Rcon password
 commands                | commands.json  | Commands configuration file in JSON format (rconcommand module)
 whitelist               | whitelist.json | stores the whitelisted players used by rconwhitelist module
 restart : interval      | 240            | Restart interval in minutes
+restart : delay         | 15             | Wait x seconds until shutdown after players have been kicked
 restart : exitonrestart | true           | End the application when restart interval has reached
 
 GUI

--- a/configexample.json
+++ b/configexample.json
@@ -10,6 +10,7 @@
 	"whitelist": "whitelist.json",
 	"restart": {
 		"interval": 240,
+		"delay": 15,
 		"exitonrestart": true,
 		"messages": [
 			[

--- a/lib/rconprotocol.py
+++ b/lib/rconprotocol.py
@@ -36,7 +36,7 @@ class Rcon():
         self.isExit = False
         self.isAuthenticated = False
         self.retry = 0
-        self.seq = 0
+
         self.lastcmd = ""
 
         # server message receive filters
@@ -112,7 +112,7 @@ class Rcon():
         command = bytearray()
         command.append(0xFF)
         command.append(0x01)
-        command.append(self.seq)
+        command.append(0x00)
 
         if toSendCommand:
             logging.debug('Sending command "{}"'.format(toSendCommand))
@@ -127,7 +127,6 @@ class Rcon():
         request.extend(command)
 
         self.s.sendto(request ,(self.ip, self.port))
-        self.seq += 1
 
     """
     private: send the magic bytes to login as Rcon admin.
@@ -153,6 +152,7 @@ class Rcon():
     More Info: http://www.battleye.com/downloads/BERConProtocol.txt
     """
     def _acknowledge(self, Bytes):
+        
         command = bytearray()
         command.append(0xFF)
         command.append(0x02)
@@ -161,6 +161,10 @@ class Rcon():
         request = bytearray(b'BE')
         request.extend( self.__compute_crc(command) )
         request.extend(command)
+
+        seqNo = Bytes[0]
+
+        logging.info('ACK seq:{}'.format(seqNo))
 
         return request
 
@@ -177,9 +181,7 @@ class Rcon():
         try:
             if p[0:2] == b'BE' and self.isAuthenticated:
                 self.s.sendto(self._acknowledge(p[8:9]), (self.ip, self.port))
-                self.seq -= 1
-                if self.seq < 0: self.seq = 0
-                    
+
         except:
             pass
         
@@ -267,9 +269,10 @@ class Rcon():
     """
     def kickAll(self):
         logging.info('Kick All player before restart take action')
+
         for i in range(1, 100):
             self.sendCommand('kick %s' % (i))
-            time.sleep(0.1)
+            time.sleep(0.05)
 
     """
     public: lock the server (until next restart/unlock). So nobody can join anymore
@@ -380,7 +383,6 @@ class Rcon():
             logging.error('Socket timeout: {}'.format(et))
             if self.retry < self.ConnectionRetries and not self.isExit:
                 self.retry += 1
-                self.seq = 0
                 self.connect()
             else:
                 self.Abort()

--- a/lib/rconprotocol.py
+++ b/lib/rconprotocol.py
@@ -380,6 +380,7 @@ class Rcon():
             logging.error('Socket timeout: {}'.format(et))
             if self.retry < self.ConnectionRetries and not self.isExit:
                 self.retry += 1
+                self.seq = 0
                 self.connect()
             else:
                 self.Abort()

--- a/lib/rconrestart.py
+++ b/lib/rconrestart.py
@@ -83,12 +83,12 @@ class RconRestart(object):
     private: the actual shutdown call (with some delay to make sure players are disconnected)
     """
     def _shutdownTask(self):
-        self.rcon.lockServer();
+        self.rcon.lockServer()
         self.rcon.kickAll()
 
         # wait some seconds before restarting
         logging.info('Delay the shutdown process')
-        time.sleep(30)
+        time.sleep(15)
 
         logging.info('Sending shutdown command')
         self.rcon.sendCommand('#shutdown')

--- a/lib/rconrestart.py
+++ b/lib/rconrestart.py
@@ -22,7 +22,7 @@ class RconRestart(object):
         self.canceled = False
         self.rcon = rcon
 
-        self.shutdownDelay = config['delay'] if 'delay' in config else 15
+        self.shutdownDelay = config['delay'] if 'delay' in config and config['delay'] >= 5 else 15
 
         self.setMessages(config['messages'])
         self.setInterval(config['interval'])

--- a/lib/rconrestart.py
+++ b/lib/rconrestart.py
@@ -18,9 +18,11 @@ class RconRestart(object):
         self.shutdownTimer = 0
         self.restartMessages = None
         self.exitOnRestart = False
-
+        self.inProgress = False
         self.canceled = False
         self.rcon = rcon
+
+        self.shutdownDelay = config['delay'] if 'delay' in config else 15
 
         self.setMessages(config['messages'])
         self.setInterval(config['interval'])
@@ -62,7 +64,7 @@ class RconRestart(object):
     When connection is established start the "restart" schedule
     """
     def OnConnected(self):
-        if self.shutdownTimer > 0:
+        if self.shutdownTimer > 0 and self.inProgress == False:
             # a separate thread to handle the restart and restart messages
             # It is set as daemon to be able to stop it using SystemExit or Ctrl + C
             t = threading.Thread(target=self._initRestartScheduler)
@@ -71,6 +73,17 @@ class RconRestart(object):
             logging.info('OnConnect(): %s ready to restart server every %d seconds' % (type(self).__name__, self.shutdownTimer))
         else:
             logging.info("OnConnect(): %s disabled" % type(self).__name__)
+
+    """
+    Event: Called from Rcon.OnReconnected()
+    """
+    def OnReconnected(self):
+        if self.shutdownTimer > 0 and self.inProgress == False:
+            # restart the module
+            t = threading.Thread(target=self._initRestartScheduler)
+            t.daemon = True
+            t.start()
+            logging.info('OnReconnect(): %s ready to restart server every %d seconds' % (type(self).__name__, self.shutdownTimer))
 
     """
     private: restart message to warn the players
@@ -83,15 +96,17 @@ class RconRestart(object):
     private: the actual shutdown call (with some delay to make sure players are disconnected)
     """
     def _shutdownTask(self):
+        self.inProgress = True
         self.rcon.lockServer()
         self.rcon.kickAll()
 
         # wait some seconds before restarting
         logging.info('Delay the shutdown process')
-        time.sleep(15)
+        time.sleep(self.shutdownDelay)
 
         logging.info('Sending shutdown command')
         self.rcon.sendCommand('#shutdown')
+        self.inProgress = False
 
     """
     private: Clear all schedules

--- a/py3rcon.py
+++ b/py3rcon.py
@@ -7,7 +7,7 @@ from lib.rconprotocol import Rcon
 pid = str(os.getpid())
 
 _DESC = 'Python Rcon CLI for Arma servers'
-_VER = '0.2'
+_VER = '0.2.1'
 
 parser = argparse.ArgumentParser(description=_DESC)
 parser.add_argument('configfile', help='configuration file in JSON')


### PR DESCRIPTION
- fixed possible issue when `exitonrestart:` is set to false
- added new setting to customize the restart delay (after kick)
- fixed the BER sequence as it seem to not properly work from Battleye (only sequence 0x00 can be reused)